### PR TITLE
Bugfix: Fix minor annoyance when commenting out bar section

### DIFF
--- a/j4-make-config
+++ b/j4-make-config
@@ -213,10 +213,11 @@ if __name__ == "__main__":
 	# iterate over base config lines, write all to config file
 	# and insert theme config at the right place
 	for line in baselines_list:
-		if "$i3-theme-window" in line:
+		line = line.lstrip()
+		if line.startswith("# $i3-theme-window"):
 			if not noTheme:
 				configfile.write(windowText)
-		elif "$i3-theme-bar" in line:
+		elif line.startswith("# $i3-theme-bar"):
 			if not noTheme:
 				configfile.write(barText)
 		else:


### PR DESCRIPTION
I run into this bug occasionally only when I want to change the number of bars on my monitors. When I want to use one bar instead of two, I will comment out a bar section like this...
```
# bar {
#    # $i3-theme-bar
#    workspace_buttons no
#    tray_output none
# }
```
I have to modify `# $i3-theme-* ` slightly (such as omitting `$`) to stop receiving `i3-nagbar` about broken config on i3 restart. Here, we make sure it's only one `#` + `$i3-theme-window` on the line.

I suppose this can break some user's config if they have existing comments that does not follow your `README` such as `## $i3-theme-window`, `# $i3-theme-window #`, etc.

Let me know if you want to do something slightly different. Thanks. 